### PR TITLE
Add ability to build RPMs via Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *~
 doc/*.links
 doc/*.refs
+pkg/
+dist/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+prefix := /usr
+sysconfdir := /etc
+sbindir := $(prefix)/sbin
+datadir := $(prefix)/share
+mandir := $(datadir)/man
+version := 1.0.3
+relversion := 1
+tmpdir := /tmp
+builddir := simplesnap-$(version)
+topdir := $(shell pwd)/pkg
+
+_default:
+	@echo "No default. Try 'make install'"
+
+install:
+	install -d $(DESTDIR)$(mandir)/man8
+	install doc/simplesnap.8 $(DESTDIR)$(mandir)/man8/simplesnap.8
+	install -d $(DESTDIR)$(sbindir)
+	install simplesnap $(DESTDIR)$(sbindir)/simplesnap
+	install simplesnapwrap $(DESTDIR)$(sbindir)/simplesnapwrap
+
+clean:
+	rm -rf dist/
+	rm -rf pkg/
+	rm -rf $(tmpdir)/$(builddir)
+
+build:
+	mkdir -p $(tmpdir)/$(builddir)
+	cp -r doc $(tmpdir)/$(builddir)/
+	cp -r examples $(tmpdir)/$(builddir)/
+	cp COPYING INSTALL.txt Makefile README.txt simplesnap simplesnapwrap TODO $(tmpdir)/$(builddir)/
+	mkdir -p dist
+	tar -czf dist/simplesnap-$(version).tar.gz -C $(tmpdir) simplesnap-$(version)
+
+rpm: build
+	mkdir -p $(topdir)
+	cp dist/simplesnap-$(version).tar.gz $(topdir)/
+	rpmbuild --define "_topdir $(topdir)" \
+	--define "_builddir %{_topdir}" \
+	--define "_rpmdir %{_topdir}" \
+	--define "_srcrpmdir %{_topdir}" \
+	--define "_specdir %{_topdir}" \
+ 	--define "_sourcedir  %{_topdir}" \
+	--define "version $(version)" \
+	--define "relversion $(relversion)" \
+	-ba redhat/simplesnap.spec

--- a/redhat/simplesnap.spec
+++ b/redhat/simplesnap.spec
@@ -1,0 +1,39 @@
+Name:           simplesnap
+Version:        %{?version}
+Release:        %{?relversion}%{?dist}
+Summary:        A simple and powerful way to send ZFS snapshots across a network
+License:        GPLv2+
+Group:          Applications/System
+URL:            https://github.com/jgoerzen/%{name}
+Source0:        %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+Requires:       liblockfile
+
+%description
+A simple and powerful way to send ZFS snapshots across a network
+
+%prep
+%setup -qn %{name}-%{version}
+
+%build
+# Do nothing
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+make install DESTDIR=$RPM_BUILD_ROOT
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%doc README.txt INSTALL.txt TODO COPYING examples
+%attr(0755, root, root) %{_sbindir}/simplesnap
+%attr(0755, root, root) %{_sbindir}/simplesnapwrap
+%{_mandir}/man8/simplesnap.8.gz
+
+%changelog
+* Thu Jul 24 2014 Trey Dockendorf <treydock@gmail.com> %{version}
+- Initial spec file creation


### PR DESCRIPTION
To build the RPMs

```
make rpm
```

The current files will produce pkg/noarch/simplesnap-1.0.3-1.el6.noarch.rpm when built on a CentOS 6 system.