### PR TITLE
trap: do not define ECODE at setup

### DIFF
--- a/simplesnap
+++ b/simplesnap
@@ -239,14 +239,15 @@ if [ ! -d "${MOUNTPOINT}/${HOST}" ]; then
 fi
 
 LOCKFILE="${MOUNTPOINT}/${HOST}/.lock"
+printf -v EVAL_SAFE_LOCKFILE '%q' "$LOCKFILE"
 
 if [ x"$LOCKMETHOD" = x"dotlockfile" ] && ${LOCKMETHOD} -r 0 -l -p "${LOCKFILE}" ; then
   logit "Lock obtained at ${LOCKFILE} with dotlockfile"
-  trap "ECODE=$?; dotlockfile -u \"${LOCKFILE}\"; exit $ECODE" EXIT INT TERM
+  trap 'ECODE=$?; dotlockfile -u '"${EVAL_SAFE_LOCKFILE}"'; exit $ECODE' EXIT INT TERM
 elif [ x"$LOCKMETHOD" = x"mkdir" ]; then
     ${LOCKMETHOD} "${LOCKFILE}" || exiterror "Could not obtain lock at ${LOCKFILE}; if $0 is not already running, rmdir that path."
     logit "Lock obtained at ${LOCKFILE} with mkdir"
-    trap "ECODE=$?; rmdir \"${LOCKFILE}\"" EXIT INT TERM
+    trap 'ECODE=$?; rmdir '"${EVAL_SAFE_LOCKFILE}"'; exit $ECODE' EXIT INT TERM
 else
     exiterror "Could not obtain lock at ${LOCKFILE}; $0 likely already running."
 fi


### PR DESCRIPTION
We need to delay defining ECODE until we call the trap

Before this change (set -x output):
```bash
+ trap 'ECODE=0; dotlockfile -u "/mypool2/simplesnap/storage01/.lock"; exit ' EXIT INT TERM
```

After:
```bash
+ trap 'ECODE=$?; dotlockfile -u /mypool2/simplesnap/storage01/.lock; exit $ECODE' EXIT INT TERM
```