### PR TITLE
Add MacOS compatibility to simplesnapwrap

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -19,6 +19,11 @@ probably work on FreeBSD or Solaris as well, especially if the GNU
 tools are installed or available under "g" names.  The script will try
 to find them with those names and use them if possible.
 
+  To install MacOS prerequisites using Homebrew (https://brew.sh):
+
+   * brew install coreutils grep gnu-sed liblockfile
+
+
 INSTALLATION
 
 Copy simplesnap somewhere on the host that will store backups and mark

--- a/simplesnapwrap
+++ b/simplesnapwrap
@@ -41,13 +41,16 @@ runzfs () {
   fi
 }
 
-DATE="gdate"
-gdate &> /dev/null || DATE="date"
-SED="gsed"
-gsed &> /dev/null || SED="sed"
-GREP="ggrep"
-ggrep &> /dev/null || GREP="grep"
+if [ "$(uname)" = Darwin ] ; then
+   PATH=$PATH:/usr/local/bin
+   ZFSCMD="zfs"
+fi
 
+# POSIX compatible program validation
+command -v gdate > /dev/null && DATE="gdate" || DATE="date"
+command -v gsed  > /dev/null && SED="gsed"   || SED="sed"
+command -v ggrep > /dev/null && GREP="ggrep" || GREP="grep"
+command -v ghead > /dev/null && HEAD="ghead" || HEAD="head"
 
 # template - $1
 # dataset - $2
@@ -58,14 +61,14 @@ listsnaps () {
 PATTERN="^[a-zA-Z0-9_/. -]\+\$"
 if [ "$1" = "reinvoked" ]; then
   shift
-  logit "Reinvoked with paramters \"$*\""
+  logit "Reinvoked with parameters \"$*\""
   shift # Drop the call to simplesnapwrap
 
   # Validate again.  Just to be sure.
   echo ".$*" | $GREP -q "${PATTERN}" || exiterror "Invalid characters found on re-validate; pattern is ${PATTERN}"
   echo ".$*" | $GREP -vq '\.\.' || exiterror "Found .. in input; aborting."
 
-  # We don't want any paramters to contain a space or leading dash.
+  # We don't want any parameters to contain a space or leading dash.
   for ARG; do
     echo ",${ARG}" | $GREP -vq '^,-' || exiterror "Found leading '-' in parameter \"${ARG}\"; aborting."
     echo ",${ARG}" | $GREP -vq ' ' || exiterror "Found space in parameters; aborting."
@@ -90,7 +93,7 @@ if [ "$1" = "reinvoked" ]; then
 
        logit "Listing snapshots on \"${DATASET}\" with template \"${TEMPLATE}\""
 
-       OLDESTSNAP="`listsnaps \"${TEMPLATE}\" \"${DATASET}\" | head -n 1`"
+       OLDESTSNAP="`listsnaps \"${TEMPLATE}\" \"${DATASET}\" | $HEAD -n 1`"
        if [ -z "${OLDESTSNAP}" ]; then
          logit "Found no existing snapshot."
        else
@@ -124,7 +127,7 @@ if [ "$1" = "reinvoked" ]; then
        [ -z "$1" ] && exiterror "No template given."
         
        # We always save the most recent.
-       SNAPSTOREMOVE="`listsnaps \"${TEMPLATE}\" \"${DATASET}\" | head -n -1`"
+       SNAPSTOREMOVE="`listsnaps \"${TEMPLATE}\" \"${DATASET}\" | $HEAD -n -1`"
        if [ -z "${SNAPSTOREMOVE}" ]; then
          logit "No snapshots to remove."
        else


### PR DESCRIPTION
1. Revised INSTALL.txt to include MacOS prerequisites.
2. Revised PATH on MacOS, as the following [Homebrew](https://brew.sh)-installed commands are found in /usr/local/bin:
   - zfs, as installed by 'brew cask install openzfs'
   - gdate & ghead, as installed by 'brew install coreutils'
   - ggrep, as installed by 'brew install grep'
   - gsed, as installed by 'brew install gnu-sed'
3. Revised script to use `ghead`, if available.
4. Added POSIX compatible program validation, using 'command -v'.
5. Corrected misc spelling errors.

Closes #22